### PR TITLE
Added missing tcpwrappers_line.content for hosts.deny

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
         name: /etc/hosts.deny
         backup: yes
         state: "{{ tcpwrappers_line.state }}"
-        line: "{{ tcpwrappers_line }}"
+        line: "{{ tcpwrappers_line.content }}"
         create: yes
         owner: root
         group: root


### PR DESCRIPTION
When running the task with `ALL: ALL` in `hosts.deny` like described in the examples, ansible would throw a warning: 
```
[WARNING]: The value {'content': 'ALL:ALL', 'state':'present'} (type dict) in a string field was converted to...
```
Furthermore, the `hosts.deny` would be populated with the string literal
`{'content': 'ALL:ALL', 'state':'present'}`
However, the expected content should simply be
`ALL:ALL` for `hosts.deny` to be effective.

The issue has been solved by adding `.content` to `tcpwrappers_line` like it has been done in the upper task for hosts.allow.